### PR TITLE
Making images for RSS feeds on S3 public by default

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  # The RSS feeds that minicast serves are public.  Signed S3 URLs time out, so let's construct
+  # a URL that will be public as long as the feed is.
+  def public_url(image)
+    if Rails.env.production?
+      "#{ENV["PUBLIC_S3_URL"]}/#{image.blob.key}"
+    else
+      image.url
+    end
+  end
 end

--- a/app/views/feeds/show.xml.erb
+++ b/app/views/feeds/show.xml.erb
@@ -10,7 +10,7 @@
     <itunes:email><%= tag_from_main("//itunes:email") %></itunes:email>
   </itunes:owner>
   <itunes:author><%= tag_from_main("/rss/channel/itunes:author") %></itunes:author>
-  <itunes:image href="<%= @mini_feed.image.url %>"></itunes:image>
+  <itunes:image href="<%= public_url(@mini_feed.image) %>"></itunes:image>
   <itunes:category><%= tag_from_main("/rss/channel/itunes:category") %></itunes:category>
   <googleplay:block><%= tag_from_main("/rss/channel/googleplay:block") %></googleplay:block>
   <itunes:block><%= tag_from_main("/rss/channel/itunes:block") %></itunes:block>
@@ -18,7 +18,7 @@
   <pubDate><%= tag_from_main("/rss/channel/pubDate") %></pubDate>
   <lastBuildDate><%= tag_from_main("/rss/channel/lastBuildDate") %></lastBuildDate>
   <image>
-    <url><%= @mini_feed.image.url %></url>
+    <url><%= public_url(@mini_feed.image) %></url>
     <title><%= @mini_feed.name %></title>
     <link><%= tag_from_main("/rss/channel/link") %></link>
   </image>


### PR DESCRIPTION
The RSS feed is public and signed S3 URLs time out.  This makes the image privacy settings match the RSS feed privacy settings.